### PR TITLE
Pass template path to mjml2html in sendmail

### DIFF
--- a/src/sendmail/index.js
+++ b/src/sendmail/index.js
@@ -17,7 +17,7 @@ function sendmail({ to, subject, text, template, data, onError = () => {} }) {
         return;
       }
 
-      let { html } = mjml2html(rawTemplate);
+      let { html } = mjml2html(rawTemplate, { filePath: template });
 
       Object.keys(data).forEach((key) => {
         const regex = new RegExp(`{${key}}`, 'g');


### PR DESCRIPTION
Hello!

Very small PR, but as it's my first, and as a relative newcomer to mjml & mjml-utils it's probably worth me taking some time to explain my use case to make sure I'm not missing something in the wider goals for the package. 

I've been using the mjml desktop app with it's excellent preview pane to design my app's transactional email templates. (Combined with this lib's integrations with nodemailer, I've never experienced such an enjoyable email dev experience, so thank you!) I lean heavily on `mj-include`  to maximise reusability of various components. Using the desktop app, relative paths are supported without issue. When using mjml-utils' `sendmail` function however the relative paths are computed relative to the current node process, which is inevitably not the path that my partials are defined from. 

This PR simply passes the template string to `mjml2html` function to allow it to resolve the `mj-include` paths correctly.