### PR TITLE
Add check to skip reading subdirectories as a file

### DIFF
--- a/src/builder/index.js
+++ b/src/builder/index.js
@@ -19,6 +19,9 @@ function mkdir(directory) {
 }
 
 builder.build = (filePath, outputDir, extension) => {
+  // Silently fail if given filePath is not a file
+  if (!fs.statSync(filePath).isFile()) return;
+
   const filename = getTemplateFilename(filePath).replace('.mjml', extension);
 
   try {


### PR DESCRIPTION
If a user whishes to have subdirectories, the builder now gives an error:

```
templates/
├── partials/
│   ├── footer.mjml
│   └── header.mjml
└── index.mjml
```

```shell
Unable to render partials
EISDIR: illegal operation on a directory, read
```

This PR fixes that by not reading folders as files.